### PR TITLE
修复在Firefox中popup不正常处理触底滑动的bug

### DIFF
--- a/src/popup/index.css
+++ b/src/popup/index.css
@@ -1,6 +1,7 @@
 body {
     width: 350px;
     height: 500px;
+    overflow: hidden;
 }
 
 .mdui-toolbar {


### PR DESCRIPTION
在Firefox中，如果在popup设置窗口中一直向下滚动，菜单页面并不会停止滑动，而会继续滑动下去，如图。

![a2023-06-21_05-28](https://github.com/Proj-MExt/MExt-Extension/assets/22428650/6545a194-3bcb-439e-9b4b-85815ff5c209)
